### PR TITLE
Problem: MemoryContext-related issues

### DIFF
--- a/pgx-pg-sys/cshim/pgx-cshim.c
+++ b/pgx-pg-sys/cshim/pgx-cshim.c
@@ -33,6 +33,11 @@ MemoryContext pgx_GetMemoryContextChunk(void *ptr) {
     return GetMemoryChunkContext(ptr);
 }
 
+PGDLLEXPORT bool pgx_MemoryContextIsValid(MemoryContext context);
+bool pgx_MemoryContextIsValid(MemoryContext context) {
+    return MemoryContextIsValid(context);
+}
+
 PGDLLEXPORT void pgx_elog(int32 level, char *message);
 void pgx_elog(int32 level, char *message) {
     elog(level, "%s", message);


### PR DESCRIPTION
1. When an owned context is set as current twice, dropping it will fail or result in current context being deleted.

2. When an owned context is dropped, but one of its children is current, it will fail or will result in current context being deleted.

Solution: handle these cases

Ensure double `set_as_current` doesn't obliterate the reference to "previous" context.

Ensure we're checking if any children are current, and if they are, change current context to the previous context of the context being dropped.