### PR TITLE
Make non-updating queries use readonly unless there was a mutation before

### DIFF
--- a/pgx-tests/src/tests/bgworker_tests.rs
+++ b/pgx-tests/src/tests/bgworker_tests.rs
@@ -25,7 +25,7 @@ pub extern "C" fn bgworker(arg: pg_sys::Datum) {
     if arg > 0 {
         BackgroundWorker::transaction(|| {
             Spi::run("CREATE TABLE tests.bgworker_test (v INTEGER);");
-            Spi::execute(|client| {
+            Spi::execute(|mut client| {
                 client.update(
                     "INSERT INTO tests.bgworker_test VALUES ($1);",
                     None,
@@ -70,7 +70,7 @@ pub extern "C" fn bgworker_return_value(arg: pg_sys::Datum) {
     };
     while BackgroundWorker::wait_latch(Some(Duration::from_millis(100))) {}
     BackgroundWorker::transaction(|| {
-        Spi::execute(|c| {
+        Spi::execute(|mut c| {
             c.update(
                 "INSERT INTO tests.bgworker_test_return VALUES ($1)",
                 None,

--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -177,7 +177,7 @@ mod tests {
 
     #[pg_test]
     fn test_inserting_null() {
-        Spi::execute(|client| {
+        Spi::execute(|mut client| {
             client.update("CREATE TABLE tests.null_test (id uuid)", None, None);
         });
         let result = Spi::get_one_with_args::<i32>(
@@ -189,7 +189,7 @@ mod tests {
 
     #[pg_test]
     fn test_cursor() {
-        Spi::execute(|client| {
+        Spi::execute(|mut client| {
             client.update("CREATE TABLE tests.cursor_table (id int)", None, None);
             client.update(
                 "INSERT INTO tests.cursor_table (id) \
@@ -211,7 +211,7 @@ mod tests {
 
     #[pg_test]
     fn test_cursor_by_name() {
-        let cursor_name = Spi::connect(|client| {
+        let cursor_name = Spi::connect(|mut client| {
             client.update("CREATE TABLE tests.cursor_table (id int)", None, None);
             client.update(
                 "INSERT INTO tests.cursor_table (id) \
@@ -275,7 +275,7 @@ mod tests {
             assert_eq!(res.column_name(2).unwrap(), "b");
         });
 
-        Spi::execute(|client| {
+        Spi::execute(|mut client| {
             let res = client.update("SET TIME ZONE 'PST8PDT'", None, None);
 
             assert_eq!(0, res.columns());
@@ -291,7 +291,7 @@ mod tests {
     #[pg_test]
     fn test_spi_non_mut() {
         // Ensures update and cursor APIs do not need mutable reference to SpiClient
-        Spi::execute(|client| {
+        Spi::execute(|mut client| {
             client.update("SELECT 1", None, None);
             let cursor = client.open_cursor("SELECT 1", None).detach_into_name();
             client.find_cursor(&cursor);

--- a/pgx-tests/src/tests/srf_tests.rs
+++ b/pgx-tests/src/tests/srf_tests.rs
@@ -177,7 +177,7 @@ mod tests {
 
     #[pg_test]
     fn test_srf_setof_datum_detoasting_with_borrow() {
-        let cnt = Spi::connect(|client| {
+        let cnt = Spi::connect(|mut client| {
             // build up a table with one large column that Postgres will be forced to TOAST
             client.update("CREATE TABLE test_srf_datum_detoasting AS SELECT array_to_string(array_agg(g),' ') s FROM (SELECT 'a' g FROM generate_series(1, 1000000)) x;", None, None);
 
@@ -195,7 +195,7 @@ mod tests {
 
     #[pg_test]
     fn test_srf_table_datum_detoasting_with_borrow() {
-        let cnt = Spi::connect(|client| {
+        let cnt = Spi::connect(|mut client| {
             // build up a table with one large column that Postgres will be forced to TOAST
             client.update("CREATE TABLE test_srf_datum_detoasting AS SELECT array_to_string(array_agg(g),' ') s FROM (SELECT 'a' g FROM generate_series(1, 1000000)) x;", None, None);
 

--- a/pgx-tests/src/tests/struct_type_tests.rs
+++ b/pgx-tests/src/tests/struct_type_tests.rs
@@ -128,7 +128,7 @@ mod tests {
 
     #[pg_test]
     fn test_complex_storage_and_retrieval() {
-        let complex = Spi::connect(|client| {
+        let complex = Spi::connect(|mut client| {
             Ok(client.update(
                 "CREATE TABLE complex_test AS SELECT s as id, (s || '.0, 2.0' || s)::complex as value FROM generate_series(1, 1000) s;\
                 SELECT value FROM complex_test ORDER BY id;", None, None).first().get_one::<PgBox<Complex>>())


### PR DESCRIPTION
Problem: not using readonly flag for SPI commands

We're potentially losing out on some optimizations.

Solution: track use of mutating commands

In my unscientific benchmarks, I saw a 4-5% performance increase when doing repetitive SELECT queries as read-only vs. read-write.

This is an API-breaking change (again), but it would avoid leaving performance on the table for little convenience gain.